### PR TITLE
Fix webpack build #24

### DIFF
--- a/ElectionStatistics.WebSite/ClientApp/Highchart/Component.tsx
+++ b/ElectionStatistics.WebSite/ClientApp/Highchart/Component.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 
 import * as Highcharts from 'highcharts';
-import * as HighchartsExporting from 'highcharts/modules/exporting';
+import HighchartsExporting from 'highcharts/modules/exporting';
 (HighchartsExporting as any)(Highcharts);
 
 export class HighchartComponent extends React.Component<{options: Highcharts.Options}, {}> {
     private chartRef?: HTMLElement;
-   
+
     public componentDidMount() {
         this.renderChart();
     }
-    
+
     public render() {
         return <div ref={this.setChartRef.bind(this)} />;
     }

--- a/ElectionStatistics.WebSite/tsconfig.json
+++ b/ElectionStatistics.WebSite/tsconfig.json
@@ -8,7 +8,9 @@
     "sourceMap": true,
     "skipDefaultLibCheck": true,
     "strict": true,
-    "types": ["webpack-env"]
+    "types": ["webpack-env"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
       "bin",


### PR DESCRIPTION
Опции компилятора TS:
```allowSyntheticDefaultImports``` - указывает загрузчику модулей создавать самому default import
```esModuleInterop``` - разрешает default imports к модулям commonjs ([рекомендован разработчиками TS](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html))